### PR TITLE
change feeds order 'created_at' to 'posted_at'

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,7 +1,7 @@
 class FeedsController < ApplicationController
   def index
     @feeds = Feed.all  #controllarにわたされる
-    @items = Item.order('created_at desc').includes(:feed).all
+    @items = Item.order('posted_at desc').includes(:feed).all
   end
 
   def new


### PR DESCRIPTION
item が created_at （DBに書き込まれたタイムスタンプ） 順で流れるようになっていたので、
posted_ad （エントリが投稿されたタイムスタンプ）順で流れるように修正しました。

ちなみに、`desc` は「降順」
