### PR TITLE
spec_helper is correct

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe User, :type => :model do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
userモデル作った時にも、`spec_helper`ではなくて`rails_helper`だった。
