### PR TITLE
Cleanup gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,59 +1,31 @@
 source 'https://rubygems.org'
-
 ruby '2.1.5'
 
 gem 'rails'
-
-# Bundle edge Rails instead:
-# gem 'rails', :git => 'git://github.com/rails/rails.git'
-
-group :development do
-  gem 'sqlite3'
-end
-group :production do
-  gem 'pg'
-  gem 'rails_12factor'
-end
-
-# Gems used only for assets and not required
-# in production environments by default.
-group :assets do
-  gem 'sass-rails'
-  gem 'coffee-rails'
-
-  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-  # gem 'therubyracer', :platforms => :ruby
-
-  gem 'uglifier'
-end
-
 gem 'jquery-rails'
-
 gem 'feedjira'
-
 gem 'feed_searcher'
 gem 'kaminari'
 gem 'kaminari-bootstrap'
 gem 'devise'
-
-# To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
-
-# To use Jbuilder templates for JSON
-# gem 'jbuilder'
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
-# Deploy with Capistrano
-# gem 'capistrano'
-
-# To use debugger
-# gem 'debugger'
-
 gem 'bootstrap-sass'
-
 gem 'haml-rails'
+gem 'whenever', :require => false
+
+group :assets do
+  gem 'sass-rails'
+  gem 'coffee-rails'
+  gem 'uglifier'
+end
+
+group :development do
+  gem 'sqlite3'
+end
+
+group :production do
+  gem 'pg'
+  gem 'rails_12factor'
+end
 
 group :development, :test do
   gem 'erb2haml'
@@ -67,5 +39,3 @@ group :test do
   gem 'launchy'
   gem 'factory_girl_rails'
 end
-
-gem 'whenever', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,9 @@ gem 'bootstrap-sass'
 gem 'haml-rails'
 gem 'whenever', :require => false
 
-group :assets do
-  gem 'sass-rails'
-  gem 'coffee-rails'
-  gem 'uglifier'
-end
+gem 'sass-rails'
+gem 'coffee-rails'
+gem 'uglifier'
 
 group :development do
   gem 'sqlite3'


### PR DESCRIPTION
#77 

Rails4にしたから、`group :assets`書かなくてよくなっていたみたいだったので、消しました。

http://stackoverflow.com/questions/16406204/why-did-rails4-drop-support-for-assets-group-in-the-gemfile