### PR TITLE
すべてのテーブルの created_at, updated_at に NULL 制約がつくようにした

### DIFF
--- a/db/migrate/20150303143021_change_column_timestamps.rb
+++ b/db/migrate/20150303143021_change_column_timestamps.rb
@@ -1,0 +1,23 @@
+class ChangeColumnTimestamps < ActiveRecord::Migration
+  def up
+    change_column_null :feeds, :created_at, false
+    change_column_null :feeds, :updated_at, false
+
+    change_column_null :items, :created_at, false
+    change_column_null :items, :updated_at, false
+
+    change_column_null :users, :created_at, false
+    change_column_null :users, :updated_at, false
+  end
+
+  def down
+    change_column_null :feeds, :created_at, true
+    change_column_null :feeds, :updated_at, true
+
+    change_column_null :items, :created_at, true
+    change_column_null :items, :updated_at, true
+
+    change_column_null :users, :created_at, true
+    change_column_null :users, :updated_at, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141202162733) do
+ActiveRecord::Schema.define(version: 20150303143021) do
 
   create_table "feeds", force: true do |t|
     t.string   "title"
@@ -45,8 +45,8 @@ ActiveRecord::Schema.define(version: 20141202162733) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## ブランチの概要
Rails 4.0 では、マイグレーションの `t.timestamps` で作成されるふたつのカラム `created_at` `updated_at` がデフォルトで nullable、すなわち NULL を許容するようになっているそうです。

[revert setting NOT NULL constraints in add_timestamps · fcef728 · rails/rails](https://github.com/rails/rails/commit/fcef728)

それ以前からこちらのアプリに存在していたテーブルのそれらのカラムは `null: false` になっていたため（Rails のデフォルト値のままにしていただけかもしれませんが）、それに合わせる形で、明示的に `null: false` を追加するマイグレーションを作成しました。