### PR TITLE
i18n 対応の翻訳ファイルを作った[closes #71][closes #95]

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,10 @@
+ja:
+  devise:
+    sessions:
+      user:
+        signed_in: ログインしました。
+        signed_out: ログアウトしました。
+    failure:
+      user:
+        not_found_in_database: メールアドレスかパスワードが違います。
+        invalid: メールアドレスかパスワードが違います。


### PR DESCRIPTION
i18n 対応の翻訳ファイルを作りました。

使わないのがわかっているものまで書くと見通しが悪くなってしまうなと思ったので、今の時点でアプリケーションに出ているメッセージのものだけを記述してあります。

※ `devise.en.yml` を見ると `devise.failure.invalid` のキーのメッセージは `authentication_keys` を展開して文言をつくるようなしくみになってますが、このアプリではデフォルトどおり email なので、 `メールアドレス` という固定の文字列を入れておきました。

https://github.com/katorie/rss_reader/blob/master/config/initializers/devise.rb#L24-L32
